### PR TITLE
Fix hive command typo

### DIFF
--- a/SparkTest/src/main/scala/hive/HiveUtil.scala
+++ b/SparkTest/src/main/scala/hive/HiveUtil.scala
@@ -30,7 +30,7 @@ object HiveUtil extends LazyLogging{
     println(alterLocationSql)
     session.sql(alterLocationSql)
 
-    session.sql(s""" MCSK REPAIR TABLE bdp.$tableName """)
+    session.sql(s""" MSCK REPAIR TABLE bdp.$tableName """)
     session.sql(s""" SELECT * FROM bdp.$tableName """)
       .show(10000)
   }


### PR DESCRIPTION
## Summary
- fix a typo in HiveUtil for MSCK REPAIR TABLE command

## Testing
- `mvn -v` *(fails: command not found)*
- `sbt sbtVersion` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f87d786008327ba6f77aceb51ee53